### PR TITLE
Fix file URL error on Windows

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -1,0 +1,18 @@
+name: Test Windows project creation & build
+
+on: [push]
+
+jobs:
+  create_and_build:
+
+    name: Create and build
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node bin/create-cubing-app my-cubing-project
+      - run: cd my-cubing-project && npm run build

--- a/bin/create-cubing-app.js
+++ b/bin/create-cubing-app.js
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { exit, stderr } from "node:process";
 import { createInterface } from "node:readline";
 import { promisify } from "node:util";
-import { fileURLToPath } from "node:url"
+import { fileURLToPath } from "node:url";
 
 const CREATE_CUBING_APP_PACKAGE_JSON = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf-8"),

--- a/bin/create-cubing-app.js
+++ b/bin/create-cubing-app.js
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { exit, stderr } from "node:process";
 import { createInterface } from "node:readline";
 import { promisify } from "node:util";
+import { fileURLToPath } from "node:url"
 
 const CREATE_CUBING_APP_PACKAGE_JSON = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf-8"),
@@ -65,7 +66,7 @@ Please select a different name (or delete the existing project folder).
 }
 await mkdir(projectPath, { recursive: true });
 
-const appTemplatePath = new URL("../app-template", import.meta.url).pathname;
+const appTemplatePath = fileURLToPath(new URL("../app-template", import.meta.url));
 await cp(appTemplatePath, projectPath, {
   recursive: true,
 });


### PR DESCRIPTION
On Windows, create-cubing-app errors out. Here is an example:
```
PS C:\Users\ericx> npm create --yes cubing-app@latest my-cubing-project
---------------------------------
Creating a cubing project in the following folder:
my-cubing-project

node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^

[Error: ENOENT: no such file or directory, lstat 'C:\C:\Users\ericx\AppData\Local\npm-cache\_npx\8f9f419572216059\node_modules\create-cubing-app\app-template'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'lstat',
  path: 'C:\\C:\\Users\\ericx\\AppData\\Local\\npm-cache\\_npx\\8f9f419572216059\\node_modules\\create-cubing-app\\app-template'
}
```

Line 69 of `bin/create-cubing-app.js` throws an error because of the leading slash on `appTemplatePath`.
For some reason on Windows, that makes Node `fs.cp` access a bad path with a double `C:\`. On Linux the leading slash works fine.

Solution is to use Node [`url.fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl-options) to ensure the URL is a proper absolute path on different platforms. On Windows it removes the leading slash like so:
- before: `'/C:/Users/ericx/Documents/dev/create-cubing-app/app-template'`
- after:  `'C:\\Users\\ericx\\Documents\\dev\\create-cubing-app\\app-template'`